### PR TITLE
Add background color to Footnotes component

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ Learn more about [how to use a theme](https://sli.dev/themes/use).
 
 `Footnotes` is to be used as parent of `Footnote` children.
 
-| **Parameter** | **Type** | **Values**      | **Default** |
-| ------------- | -------- | --------------- | ----------- |
-| `x`           | String   | `'l'`, `'r'`    | `'r'`       |
-| `separator`   | Boolean  | `true`, `false` | `false`     |
+| **Parameter** | **Type** | **Values**      | **Default** | **Notes**                                                       |
+| ------------- | -------- | --------------- | ----------- | --------------------------------------------------------------- |
+| `filled`      | Boolean  | `true`, `false` | `false`     | Overlay subordinate content that may puts itself in background. |
+| `separator`   | Boolean  | `true`, `false` | `false`     | -                                                               |
+| `x`           | String   | `'l'`, `'r'`    | `'r'`       | -                                                               |
 
 ### Footnote
 

--- a/components/Footnotes.vue
+++ b/components/Footnotes.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="fixed bottom-0 left-0 w-full bg-main">
+  <div
+    class="fixed bottom-0 left-0 w-full"
+    v-bind:class="{
+      'bg-main': filled,
+    }"
+  >
     <hr v-if="separator" />
     <ul
       class="flex flex-wrap !list-none p-2"
@@ -17,14 +22,18 @@
 import { PropType } from 'vue';
 
 defineProps({
-  x: {
-    default: 'r',
-    type: String as PropType<'l' | 'r'>,
-    validator: (value) => value === 'l' || value === 'r',
+  filled: {
+    default: false,
+    type: Boolean,
   },
   separator: {
     default: false,
     type: Boolean,
+  },
+  x: {
+    default: 'r',
+    type: String as PropType<'l' | 'r'>,
+    validator: (value) => value === 'l' || value === 'r',
   },
 });
 </script>

--- a/components/Footnotes.vue
+++ b/components/Footnotes.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fixed bottom-0 left-0 w-full">
+  <div class="fixed bottom-0 left-0 w-full bg-main">
     <hr v-if="separator" />
     <ul
       class="flex flex-wrap !list-none p-2"


### PR DESCRIPTION
Hi,
it's just a small change to keep the footnotes visible in case the component behind them takes up the full height (e.g `iframe-right` in my case).

![example](https://user-images.githubusercontent.com/12751931/165295600-beb3cb4b-1e91-4e2f-a61b-a28d429a2d05.png)
 