### PR TITLE
fix: load Shiki theme directly

### DIFF
--- a/setup/shiki.ts
+++ b/setup/shiki.ts
@@ -1,10 +1,10 @@
 import { defineShikiSetup } from '@slidev/types';
 
-export default defineShikiSetup(async ({ loadTheme }) => {
+export default defineShikiSetup(() => {
   return {
     theme: {
-      dark: await loadTheme(require.resolve('theme-vitesse/themes/vitesse-dark.json')),
-      light: await loadTheme(require.resolve('theme-vitesse/themes/vitesse-light.json')),
+      dark: 'vitesse-dark',
+      light: 'vitesse-light',
     },
   };
 });


### PR DESCRIPTION
Fix this warning in Slidev v0.49.29

```
[slidev] `loadTheme` in `setup/shiki.ts` is deprecated. Pass directly the theme name it's supported by Shiki. For custom themes, load it manually via `JSON.parse(fs.readFileSync(path, 'utf-8'))` and pass the raw JSON object instead.
```
